### PR TITLE
Fix driftmarker type

### DIFF
--- a/src/map/BoundsDriftMarker.tsx
+++ b/src/map/BoundsDriftMarker.tsx
@@ -1,17 +1,17 @@
-import {Rectangle, useLeaflet} from "react-leaflet";
+import {Rectangle, useLeaflet, MarkerProps as LeafletMarkerProps} from "react-leaflet";
 import React, { useState } from "react";
-//DKDK block this
-// import { DriftMarker } from "leaflet-drift-marker";
-import { MarkerProps, Bounds } from './Types';
+import { DriftMarker } from "leaflet-drift-marker";
+import { MarkerProps, Bounds, ExtractProps } from './Types';
 import { LeafletMouseEvent, LatLngBounds } from "leaflet";
-
-//DKDK use require to avoid ts error (technically check...)
-const { DriftMarker } = require('leaflet-drift-marker')
 
 export interface BoundsDriftMarkerProps extends MarkerProps {
   bounds: Bounds,
   duration: number,
 }
+
+// Wrapper component for DriftMarker to "fix" its Props type.
+// We are adding the missing LeafletMarkerProps to the existing Props type of DriftMarker.
+const FixedDriftMarker = DriftMarker as React.ComponentType<ExtractProps<typeof DriftMarker> & LeafletMarkerProps>;
 
 /*  DKDK after testing various approaches, it is found that sending mouse event props from story, like done in previous approach,
  *    seems to conflict with other mouse event like grey-box. Also, using function form of the top-marker event did not work either.
@@ -35,19 +35,19 @@ export default function BoundsDriftMarker({position, bounds, icon, duration}: Bo
   // is this the most elegant way?
   const optionalIconProp = icon ? { icon } : { };
 
-  return (<DriftMarker
+  return (<FixedDriftMarker
     duration={duration}
     position={position}
-    onMouseOver={(e: LeafletMouseEvent) => {
+    onmouseover={(e: LeafletMouseEvent) => {
       e.target._icon.classList.add('top-marker');     //DKDK marker on top
       setDisplayBounds(true);
     }} // Display bounds rectangle
-    onMouseOut={(e: LeafletMouseEvent) => {
+    onmouseout={(e: LeafletMouseEvent) => {
       e.target._icon.classList.remove('top-marker');  //DKDK remove marker on top
       setDisplayBounds(false);
     }} // Remove bounds rectangle
     {...optionalIconProp}
-    onDblClick={() => handleDoubleClick()} > 
+    ondblclick={() => handleDoubleClick()} > 
     {
       displayBounds
           ? <Rectangle
@@ -60,5 +60,5 @@ export default function BoundsDriftMarker({position, bounds, icon, duration}: Bo
           : null
 
     }
-  </DriftMarker>)
+  </FixedDriftMarker>)
 }

--- a/src/map/Types.ts
+++ b/src/map/Types.ts
@@ -49,3 +49,8 @@ export type AnimationFunction = (
     };
 
 
+/**
+ * Utility type to extract the Props type from a React Component
+ * @example type Props = ExtractProps<typeof MyComponent>;
+ */
+export type ExtractProps<T> = T extends React.ComponentType<infer Props> ? Props : never;


### PR DESCRIPTION
This PR fixes typescript issues with `DriftMarker`. The fix is local to `BoundsDriftMarker.tsx`.

I attempted to modify the type provided by the `leaflet-drift-marker` library, using [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation), but the way `DriftMarker` is defined makes this impossible at this time.

If desired, we can move the fix to a separate module, and use this instead of using `DriftMarker` directly, in the rest of the codebase.