### PR TITLE
[DK] Sidebar standalone and refinements

### DIFF
--- a/src/map/SidebarList.tsx
+++ b/src/map/SidebarList.tsx
@@ -1,0 +1,70 @@
+// DKDK an example of a sidebar component
+import React from 'react';
+import { Sidebar, Tab } from './SidebarReactCore'
+//DKDK modified version of typescript definition for react-leaflettaken
+import { SidebarProps } from './type-react-leaflet-sidebarv2'
+
+//DKDK testing to separate a component for tab content
+import TabHomeContent from './TabHomeContent'
+
+/**
+ * DKDK this is an example of Sidebar component
+ */
+export default function SidebarList(props: SidebarProps) {
+  /**
+   * DKDK think it may be better to separate Tabs as sub-components in the future?
+   */
+  let testText = 'this is Home'
+  return (
+    <Sidebar
+        id={props.id}
+        collapsed={props.collapsed}
+        position={props.position}
+        selected={props.selected}
+        closeIcon={props.closeIcon}
+        onOpen={props.onOpen}
+        onClose={props.onClose}
+    >
+        <Tab id="home" header="Home" icon="fas fa-home">
+            {/* DKDK a test to separate tab contents into a component, TabHomeContent */}
+            <TabHomeContent
+                id={'home'}
+                header={testText}
+            />
+        </Tab>
+        {/* DKDK testing disabled - greyish icon*/}
+        <Tab id="settings" header="Settings" icon="fas fa-cog" disabled>
+            <p>Change settings</p>
+        </Tab>
+        {/* DKDK add disabled tap - no header & icon, use both diabled and divider */}
+        <Tab id="gap1" header="" icon="" disabled divider>
+            <p>gap1</p>
+        </Tab>
+        <Tab id="marker-table" header="Details for selected samples" icon="fas fa-table">
+            <p>Detailed table???</p>
+        </Tab>
+        <Tab id="export" header="Export Data" icon="fas fa-download">
+            <p>Download data</p>
+        </Tab>
+        {/* DKDK add disabled tap - no header & icon, use both diabled and divider */}
+        <Tab id="gap2" header="" icon="" disabled divider>
+            <p>gap2</p>
+        </Tab>
+        <Tab id="plot" header="Summary" icon="fas fa-chart-pie">
+            <p>For plots</p>
+        </Tab>
+        {/* DKDK no box plot icon exists in fontawesome */}
+        <Tab id="boxplot" header="Box Plot" icon="fas fa-percent">
+            <p>No box plot icon exists in the fontawesome</p>
+        </Tab>
+        <Tab id="graph" header="Chart" icon="fas fa-chart-bar">
+            <p>This is for chart</p>
+        </Tab>
+        {/* DKDK placing bottom side using  anchor="bottom" attribute */}
+        <Tab id="help" header="Tutorial" icon="fas fa-question" anchor="bottom">
+            <p>Help/Tutorial</p>
+        </Tab>
+    </Sidebar>
+  );
+}
+

--- a/src/map/SidebarListArray.tsx
+++ b/src/map/SidebarListArray.tsx
@@ -1,0 +1,66 @@
+// DKDK an example of a sidebar component
+import React from 'react';
+import { Sidebar, Tab } from './SidebarReactCoreArray'
+//DKDK modified version of typescript definition for react-leaflettaken
+import { SidebarProps } from './type-react-leaflet-sidebarv2'
+
+//DKDK testing to separate a component for tab content
+import TabHomeContent from './TabHomeContent'
+
+/**
+ * DKDK this is an example of Sidebar component
+ */
+
+//DKDK add this for array testing purpose
+interface SidebarPropsArray extends SidebarProps {
+    tabItems: string[];
+    // tabAnchor: string[];
+    tabAnchor: ('top' | 'bottom' | undefined)[];
+    tabHeader: string[];
+    tabIcons: string[];
+    tabActive: boolean[];
+    //DKDK for now, set tabContentComponent to be any[] for hosting a component
+    tabContentComponent: any[];
+}
+
+//DKDK
+export default function SidebarListArray(props: SidebarPropsArray) {
+  /**
+   * DKDK think it may be better to separate Tabs as sub-components in the future?
+   */
+  let testText = 'this is Home'
+
+  /* DKDKDK testing to generate tabs based on array props
+   * However, not quite sure if this is desirable
+   * Presuming that tab icons and the locations of dividers are more or so static,
+   * then perhaps a better way is to list all tab items and only control 'disabled' of tab icon
+   */
+//
+  let renderTab = props.tabItems.map((tab, index) => {
+
+    return (
+      <Tab key={'tab' + index} id={props.tabItems[index]} header={props.tabHeader[index]} icon={props.tabIcons[index]} anchor={props.tabAnchor[index] ? props.tabAnchor[index] : undefined } disabled={props.tabActive[index]}  divider={props.tabItems[index].includes('divider') ? true : false}>
+        {props.tabContentComponent[index]}
+      </Tab>
+    )
+
+  }); //DKDK end of renderTab
+
+
+  return (
+    <Sidebar
+        id={props.id}
+        collapsed={props.collapsed}
+        position={props.position}
+        selected={props.selected}
+        closeIcon={props.closeIcon}
+        onOpen={props.onOpen}
+        onClose={props.onClose}
+    >
+        {/* DKDK call renderTab to generate tabs */}
+        {renderTab}
+
+    </Sidebar>
+  );
+}
+

--- a/src/map/SidebarListDisabled.tsx
+++ b/src/map/SidebarListDisabled.tsx
@@ -1,0 +1,76 @@
+// DKDK an example of a sidebar component
+import React from 'react';
+import { Sidebar, Tab } from './SidebarReactCoreDisabled'
+//DKDK modified version of typescript definition for react-leaflettaken
+import { SidebarProps } from './type-react-leaflet-sidebarv2'
+
+//DKDK testing to separate a component for tab content
+import TabHomeContent from './TabHomeContent'
+
+/**
+ * DKDK this is an example of Sidebar component
+ */
+
+//DKDK add this for array testing purpose
+interface SidebarPropsArray extends SidebarProps {
+    tabDisabledList: string[];
+}
+
+//DKDK added the check of disabled icon based on tabDisabledList and its id
+export default function SidebarListDisabled(props: SidebarPropsArray) {
+
+    let testText = 'this is Home'
+
+  return (
+    <Sidebar
+        id={props.id}
+        collapsed={props.collapsed}
+        position={props.position}
+        selected={props.selected}
+        closeIcon={props.closeIcon}
+        onOpen={props.onOpen}
+        onClose={props.onClose}
+    >
+        <Tab id="home" header="Home" icon="fas fa-home" disabled={props.tabDisabledList.includes('home') ? true : false}>
+            {/* DKDK a test to separate tab contents into a component, TabHomeContent */}
+            <TabHomeContent
+                id={'home'}
+                header={testText}
+            />
+        </Tab>
+        {/* DKDK testing disabled - greyish icon*/}
+        <Tab id="settings" header="Settings" icon="fas fa-cog" disabled={props.tabDisabledList.includes('settings') ? true : false}>
+            <p>Change settings</p>
+        </Tab>
+        {/* DKDK add disabled tap - no header & icon, use both diabled and divider */}
+        <Tab id="gap1" header="" icon="" disabled divider>
+            <p>gap1</p>
+        </Tab>
+        <Tab id="marker-table" header="Details for selected samples" icon="fas fa-table" disabled={props.tabDisabledList.includes('marker-table') ? true : false}>
+            <p>Detailed table???</p>
+        </Tab>
+        <Tab id="export" header="Export Data" icon="fas fa-download" disabled={props.tabDisabledList.includes('export') ? true : false}>
+            <p>Download data</p>
+        </Tab>
+        {/* DKDK add disabled tap - no header & icon, use both diabled and divider */}
+        <Tab id="gap2" header="" icon="" disabled divider>
+            <p>gap2</p>
+        </Tab>
+        <Tab id="plot" header="Summary" icon="fas fa-chart-pie" disabled={props.tabDisabledList.includes('plot') ? true : false}>
+            <p>For plots</p>
+        </Tab>
+        {/* DKDK no box plot icon exists in fontawesome */}
+        <Tab id="boxplot" header="Box Plot" icon="fas fa-percent" disabled={props.tabDisabledList.includes('boxplot') ? true : false}>
+            <p>No box plot icon exists in the fontawesome</p>
+        </Tab>
+        <Tab id="graph" header="Chart" icon="fas fa-chart-bar" disabled={props.tabDisabledList.includes('graph') ? true : false}>
+            <p>This is for chart</p>
+        </Tab>
+        {/* DKDK placing bottom side using  anchor="bottom" attribute */}
+        <Tab id="help" header="Tutorial" icon="fas fa-question" anchor="bottom" disabled={props.tabDisabledList.includes('help') ? true : false}>
+            <p>Help/Tutorial</p>
+        </Tab>
+    </Sidebar>
+  );
+}
+

--- a/src/map/SidebarReactCoreArray.tsx
+++ b/src/map/SidebarReactCoreArray.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import { MapComponent } from 'react-leaflet'
-//DKDK customized typescript by DK for react-leaflet-sidebarv2
+//DKDKDK customized typescript by DK for react-leaflet-sidebarv2-array
 import { SidebarProps, TabProps } from './type-react-leaflet-sidebarv2'
 // //DKDK add css
 // import './sidebar-style.css'
@@ -75,10 +75,16 @@ class Sidebar extends React.Component<SidebarProps, any> {
     else if (typeof(tab.props.icon) === 'object')
       icon = tab.props.icon;
     const active = tab.props.id === this.props.selected ? ' active' : '';
+    //DKDK testing disabled & divider
     const disabled = tab.props.disabled ? ' disabled' : '';
+    const divider = tab.props.divider ? ' divider' : '';
+
+    // console.log('divider =', divider)
 
     //DKDK line divider using image file (made by DK)
-    if (tab.props.disabled && tab.props.divider) {
+    //DKDKDK set different condition
+    // if (tab.props.disabled && tab.props.divider) {
+    if (disabled && divider) {
       return (
         <li className={'sidebartabs' + active + disabled} key={tab.props.id} title={tab.props.header}>
           <a href={'#' + tab.props.id} role="tab" onClick={e => tab.props.disabled || this.onOpen(e, tab.props.id)}>

--- a/src/map/SidebarReactCoreDisabled.tsx
+++ b/src/map/SidebarReactCoreDisabled.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react'
 import { MapComponent } from 'react-leaflet'
-//DKDK customized typescript by DK for react-leaflet-sidebarv2
+//DKDKDK customized typescript by DK for react-leaflet-sidebarv2-array
 import { SidebarProps, TabProps } from './type-react-leaflet-sidebarv2'
 // //DKDK add css
 // import './sidebar-style.css'
@@ -75,10 +75,16 @@ class Sidebar extends React.Component<SidebarProps, any> {
     else if (typeof(tab.props.icon) === 'object')
       icon = tab.props.icon;
     const active = tab.props.id === this.props.selected ? ' active' : '';
+    //DKDK testing disabled & divider
     const disabled = tab.props.disabled ? ' disabled' : '';
+    const divider = tab.props.divider ? ' divider' : '';
+
+    // console.log('divider =', divider)
 
     //DKDK line divider using image file (made by DK)
-    if (tab.props.disabled && tab.props.divider) {
+    //DKDKDK set different condition
+    // if (tab.props.disabled && tab.props.divider) {
+    if (disabled && divider) {
       return (
         <li className={'sidebartabs' + active + disabled} key={tab.props.id} title={tab.props.header}>
           <a href={'#' + tab.props.id} role="tab" onClick={e => tab.props.disabled || this.onOpen(e, tab.props.id)}>

--- a/src/map/SidebarStandAlone.stories.tsx
+++ b/src/map/SidebarStandAlone.stories.tsx
@@ -26,12 +26,22 @@ export const SidebarBasic = () => {
   //DKDK Sidebar state managements
   const [ sidebarCollapsed, setSidebarCollapsed ] = useState(true);
   const [ tabSelected, setTabSelected ] = useState('');   //DKDK could be used to set default active tab, e.g., 'Home', but leave blank
+
+  //DKDK this is X button/icon behavior
   const sidebarOnClose = () => {
     setSidebarCollapsed(true)
   }
+
   const sidebarOnOpen = (id: string) => {
-    setSidebarCollapsed(false)
-    setTabSelected(id)
+    //DKDK add a function to close drawer by clicking the same icon
+    if (tabSelected != id) {
+      setSidebarCollapsed(false)
+      setTabSelected(id)
+    } else {
+      setSidebarCollapsed(true)
+      //DKDK clear tabSelected so that the tab can be reopen
+      setTabSelected('')
+    }
   }
 
   return (
@@ -58,12 +68,22 @@ export const SidebarArrayProps = () => {
   //DKDK Sidebar state managements
   const [ sidebarCollapsed, setSidebarCollapsed ] = useState(true);
   const [ tabSelected, setTabSelected ] = useState('');   //DKDK could be used to set default active tab, e.g., 'Home', but leave blank
+
+  //DKDK this is X button/icon behavior
   const sidebarOnClose = () => {
     setSidebarCollapsed(true)
   }
+
   const sidebarOnOpen = (id: string) => {
-    setSidebarCollapsed(false)
-    setTabSelected(id)
+    //DKDK add a function to close drawer by clicking the same icon
+    if (tabSelected != id) {
+      setSidebarCollapsed(false)
+      setTabSelected(id)
+    } else {
+      setSidebarCollapsed(true)
+      //DKDK clear tabSelected so that the tab can be reopen
+      setTabSelected('')
+    }
   }
 
   //DKDK make array props for generating tabs
@@ -108,12 +128,22 @@ export const SidebarDisabled = () => {
   //DKDK Sidebar state managements (for categorical)
   const [ sidebarCollapsed, setSidebarCollapsed ] = useState(true);
   const [ tabSelected, setTabSelected ] = useState('');   //DKDK could be used to set default active tab, e.g., 'Home', but leave blank
+
+  //DKDK this is X button/icon behavior
   const sidebarOnClose = () => {
     setSidebarCollapsed(true)
   }
+
   const sidebarOnOpen = (id: string) => {
-    setSidebarCollapsed(false)
-    setTabSelected(id)
+    //DKDK add a function to close drawer by clicking the same icon
+    if (tabSelected != id) {
+      setSidebarCollapsed(false)
+      setTabSelected(id)
+    } else {
+      setSidebarCollapsed(true)
+      //DKDK clear tabSelected so that the tab can be reopen
+      setTabSelected('')
+    }
   }
 
   //DKDK make array props for making disabled icon(s)

--- a/src/map/SidebarStandAlone.stories.tsx
+++ b/src/map/SidebarStandAlone.stories.tsx
@@ -1,0 +1,137 @@
+/* DKDK stand alone sidebar */
+
+import React, { useState } from 'react';
+
+//DKDK for SidebarBasic()
+import SidebarList from './SidebarList'
+
+//DKDK for SidebarArrayProps()
+import SidebarListArray from './SidebarListArray'
+//DKDK testing to import component and send it to array
+import TabHomeContent from './TabHomeContent'
+
+//DKDK for SidebarDisabled()
+import SidebarListDisabled from './SidebarListDisabled'
+
+
+export default {
+  title: 'DK Sidebar Tests/Sidebar stand-alone',
+  component: SidebarList,
+};
+
+/* DKDK SidebarOnly() simply implemented a stand-alone sidebar: manually assigned tabs
+ * each tab hosts a sub-component for contents
+ */
+export const SidebarBasic = () => {
+  //DKDK Sidebar state managements
+  const [ sidebarCollapsed, setSidebarCollapsed ] = useState(true);
+  const [ tabSelected, setTabSelected ] = useState('');   //DKDK could be used to set default active tab, e.g., 'Home', but leave blank
+  const sidebarOnClose = () => {
+    setSidebarCollapsed(true)
+  }
+  const sidebarOnOpen = (id: string) => {
+    setSidebarCollapsed(false)
+    setTabSelected(id)
+  }
+
+  return (
+    //DKDK add fragment
+    <>
+      <SidebarList
+        id="leaflet-sidebar"
+        collapsed={sidebarCollapsed}
+        position='left'
+        selected={tabSelected}
+        closeIcon='fas fa-times'
+        onOpen={sidebarOnOpen}
+        onClose={sidebarOnClose}
+      />
+    </>
+  );
+}
+
+/* DKDK SidebarArrayProps() tried to dynamically generate tabs based on array props (e.g., tabItems, etc.)
+ * Each tab hosts a sub-component for contents but dynamically generated based on tabContentComponent props
+ * Although this approach seems to work fine, IMO, this is overkill and unnecessarily verbose
+ */
+export const SidebarArrayProps = () => {
+  //DKDK Sidebar state managements
+  const [ sidebarCollapsed, setSidebarCollapsed ] = useState(true);
+  const [ tabSelected, setTabSelected ] = useState('');   //DKDK could be used to set default active tab, e.g., 'Home', but leave blank
+  const sidebarOnClose = () => {
+    setSidebarCollapsed(true)
+  }
+  const sidebarOnOpen = (id: string) => {
+    setSidebarCollapsed(false)
+    setTabSelected(id)
+  }
+
+  //DKDK make array props for generating tabs
+  let tabItems = ['home','settings','divider1','marker-table','export','divider2','plot','box-plot','gragh','help']
+  let tabAnchor: ('top' | 'bottom' | undefined)[] = ['top','top','top','top','top','top','top','top','top','bottom']
+  let tabHeader = ['home header','settings header','gap header','marker-table  header','export  header','gap  header','plot  header','box-plot header','gragh header','help header']
+  let tabIcons = ['fas fa-home','fas fa-cog','','fas fa-table','fas fa-download','','fas fa-chart-pie','fas fa-percent','fas fa-chart-bar','fas fa-question']
+  let tabActive = [false,true,true,false,false,true,false,false,false,false]
+  //DKDK testing to send component with props
+  let tabContentComponent = [<TabHomeContent id={tabItems[0]} header={tabItems}/>,'settings header','gap header','marker-table  header','export  header','gap  header','plot  header','box-plot header','gragh header','help header']
+
+  return (
+    //DKDK add fragment
+    <>
+      <SidebarListArray
+        id="leaflet-sidebar"
+        collapsed={sidebarCollapsed}
+        position='left'
+        selected={tabSelected}
+        closeIcon='fas fa-times'
+        onOpen={sidebarOnOpen}
+        onClose={sidebarOnClose}
+        tabItems={tabItems}
+        tabAnchor={tabAnchor}
+        tabHeader={tabHeader}
+        tabIcons={tabIcons}
+        tabActive={tabActive}
+        tabContentComponent={tabContentComponent}
+      />
+    </>
+  );
+}
+
+/* DKDK SidebarDisabled() tried to used a concept of a template
+ * In a realistic situation, all tabs are pre-fixed and only enabled/disabled per data type or view (like Sample, Genotype, etc.)
+ * This is similar to current mapveu v1
+ * Accordingly, only single array props is utilized to list disabled tabs (for a data/view), tabDisabledList, and control it
+ * SidebarListDisabled component has all tabs listed, but dynamically controlled for enabling/disabling tab via tabDisabledList props
+ * IMO, this is arguably the most reasonable approach for our purpose
+ */
+export const SidebarDisabled = () => {
+  //DKDK Sidebar state managements (for categorical)
+  const [ sidebarCollapsed, setSidebarCollapsed ] = useState(true);
+  const [ tabSelected, setTabSelected ] = useState('');   //DKDK could be used to set default active tab, e.g., 'Home', but leave blank
+  const sidebarOnClose = () => {
+    setSidebarCollapsed(true)
+  }
+  const sidebarOnOpen = (id: string) => {
+    setSidebarCollapsed(false)
+    setTabSelected(id)
+  }
+
+  //DKDK make array props for making disabled icon(s)
+  let tabDisabledList = ['settings','export','boxplot']
+
+  return (
+    //DKDK add fragment
+    <>
+      <SidebarListDisabled
+        id="leaflet-sidebar"
+        collapsed={sidebarCollapsed}
+        position='left'
+        selected={tabSelected}
+        closeIcon='fas fa-times'
+        onOpen={sidebarOnOpen}
+        onClose={sidebarOnClose}
+        tabDisabledList={tabDisabledList}
+      />
+    </>
+  );
+}

--- a/src/map/TabHomeContent.tsx
+++ b/src/map/TabHomeContent.tsx
@@ -1,0 +1,18 @@
+/* DKDK a test component for tab home content
+*/
+
+import React from "react";
+
+//DKDK props are not decided so just use any for now
+export default function TabHomeConent(props: any) {
+  return (
+    <>
+        <br />
+        <div>
+            <p>This is a test for making a sidebar tab contents to be a sub-comopnent of Tab-Home</p>
+            <p>Testing props (for example, id & header):<br />props.id = {props.id}<br />props.header = {props.header}</p>
+        </div>
+    </>
+  );
+}
+


### PR DESCRIPTION
# sidebar works

three tests at DK sidebar tests/SidebarStandalone.stories.tsx

- SidebarBasic(): sidebar standalone
	- standalone version of sidebar but tabs are manually set
	- separating each tab's contents as a sub-component
- SidebarArrayProps()
	- sending array props to dynamically generate tabs
	- works okay but overkill, IMO
- SidebarDisabled()
	- tried to used a concept of a template
 	- In a realistic situation, all tabs are pre-fixed and only enabled/disabled tabs per data type or view (like Sample, Genotype, etc.)
 	- This is similar to the approach used in current mapveu v1
 	- Accordingly, only single array props is utilized to list disabled tabs (for a data/view), tabDisabledList, and control it
 	- SidebarListDisabled component has all tabs listed, but dynamically controlled for enabling/
 		disabling tab via tabDisabledList props (from parent)
 	- IMO, this is arguably the most reasonable approach for our purpose