### PR TITLE
[DK] addressing multiple worlds issue

### DIFF
--- a/src/map/CustomGridLayer.tsx
+++ b/src/map/CustomGridLayer.tsx
@@ -25,7 +25,9 @@ export default function CustomGridLayer() {
                 const zoomLevel = map.getZoom();
                 const geohashLevel = zoomLevelToGeohashLevel[zoomLevel];
 
-                const currentMapBounds = map.getBounds();
+                //DKDK set maxBounds (i.e., single world) here not to show gridline out of maxBounds
+                const currentMapBounds = L.latLngBounds(L.latLng(-90,-180), L.latLng(90,180))
+
                 // bfox6 - Make the current map bounds accessible to the outside world
                 setMapBounds(currentMapBounds);
                 /**

--- a/src/map/MapVEuMap.tsx
+++ b/src/map/MapVEuMap.tsx
@@ -9,9 +9,9 @@ import CustomGridLayer from "./CustomGridLayer";
 
 /**
  * Renders a Leaflet map with semantic zooming markers
- * 
- * 
- * @param props 
+ *
+ *
+ * @param props
  */
 
 interface MapVEuMapProps {
@@ -54,10 +54,20 @@ export default function MapVEuMap({viewport, height, width, onViewportChanged, m
         viewport={state}
         style={{height, width}}
         onViewportChanged={handleViewportChanged}
+        // DKDK testing worldmap issue: minZomm needs to be 2 (FHD) or 3 (4K): set to be 2
+        minZoom={2}
+        // worldCopyJump={true}
+        maxBounds={[[-90,-180],[90,180]]}
+        //DKDK no panning allowed after maxBounds
+        maxBoundsViscosity={1.0}
     >
       <TileLayer
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         attribution="&copy; <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors"
+        // DKDK testing worldmap issue - need to set here as well!
+        bounds={[[-90,-180],[90,180]]}
+        //DKDK noWrap for loading map tile within bounds
+        noWrap={true}
       />
 
       <SemanticMarkers
@@ -74,6 +84,9 @@ export default function MapVEuMap({viewport, height, width, onViewportChanged, m
           <TileLayer
             url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}"
             attribution='Tiles &copy; Esri &mdash; Source: Esri, DeLorme, NAVTEQ, USGS, Intermap, iPC, NRCAN, Esri Japan, METI, Esri China (Hong Kong), Esri (Thailand), TomTom, 2012'
+            // DKDK testing worldmap issue - with bounds props, message like 'map data not yet availalbe' is not shown
+            bounds={[[-90,-180],[90,180]]}
+            noWrap={true}
           />
         </BaseLayer>
         <BaseLayer name="terrain">
@@ -84,12 +97,18 @@ export default function MapVEuMap({viewport, height, width, onViewportChanged, m
             // minZoom='0'
             // maxZoom='18'
             // ext='png'
+            // DKDK testing worldmap issue - with bounds props, message like 'map data not yet availalbe' is not shown
+            bounds={[[-90,-180],[90,180]]}
+            noWrap={true}
           />
         </BaseLayer>
         <BaseLayer name="satellite">
           <TileLayer
             url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
             attribution='Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community'
+            // DKDK testing worldmap issue - with bounds props, message like 'map data not yet availalbe' is not shown
+            bounds={[[-90,-180],[90,180]]}
+            noWrap={true}
           />
         </BaseLayer>
         <BaseLayer name="light">
@@ -97,6 +116,9 @@ export default function MapVEuMap({viewport, height, width, onViewportChanged, m
             url="http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png"
             attribution='&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
             // maxZoom='18'
+            // DKDK testing worldmap issue - with bounds props, message like 'map data not yet availalbe' is not shown
+            bounds={[[-90,-180],[90,180]]}
+            noWrap={true}
           />
         </BaseLayer>
         <BaseLayer name="dark">
@@ -105,6 +127,9 @@ export default function MapVEuMap({viewport, height, width, onViewportChanged, m
             attribution='&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
             subdomains='abcd'
             // maxZoom='19'
+            // DKDK testing worldmap issue - with bounds props, message like 'map data not yet availalbe' is not shown
+            bounds={[[-90,-180],[90,180]]}
+            noWrap={true}
           />
         </BaseLayer>
         <BaseLayer name="OSM">
@@ -114,6 +139,9 @@ export default function MapVEuMap({viewport, height, width, onViewportChanged, m
             // minZoom='2'
             // maxZoom='18'
             // noWrap='0'
+            // DKDK testing worldmap issue - with bounds props, message like 'map data not yet availalbe' is not shown
+            bounds={[[-90,-180],[90,180]]}
+            noWrap={true}
           />
         </BaseLayer>
       </LayersControl>

--- a/src/map/MultipleWords.stories.tsx
+++ b/src/map/MultipleWords.stories.tsx
@@ -1,0 +1,67 @@
+import React, {ReactElement, useCallback, useState} from "react";
+import {BoundsViewport, MarkerProps} from "./Types";
+import MapVEuMap from "./MapVEuMap";
+import geohashAnimation from "./animation_functions/geohash";
+import testData from './test-data/geoclust-date-binning-testing-all-levels.json';
+import BoundsDriftMarker from "./BoundsDriftMarker";
+import { zoomLevelToGeohashLevel, defaultAnimationDuration } from './config/map.json';
+import './TempIconHack';
+
+export default {
+  title: 'DK multiple worlds/Marker Bounds',
+};
+
+const getMarkerElements = ({ bounds, zoomLevel }: BoundsViewport, duration : number) => {
+  const { southWest: { lat: swLat, lng: swLng }, northEast : {lat: neLat, lng: neLng} } = bounds
+  console.log(`I've been triggered with bounds=[${swLat},${swLng} TO ${neLat},${neLng}] and zoom=${zoomLevel}`);
+
+  const geohashLevel = zoomLevelToGeohashLevel[zoomLevel];
+
+  const buckets = (testData as { [key: string]: any })[`geohash_${geohashLevel}`].facets.geo.buckets.filter((bucket: any) => {
+    const ltAvg : number = bucket.ltAvg;
+    const lnAvg : number = bucket.lnAvg;
+    return ltAvg > bounds.southWest.lat &&
+	   ltAvg < bounds.northEast.lat &&
+	   lnAvg > bounds.southWest.lng &&
+	   lnAvg < bounds.northEast.lng
+  });
+
+  return buckets.map((bucket : any) => {
+    if (bucket.val.length == geohashLevel) {
+      return (
+      <BoundsDriftMarker
+        duration={duration}
+        bounds={{ southWest: { lat: bucket.ltMin, lng: bucket.lnMin }, northEast: { lat: bucket.ltMax, lng: bucket.lnMax }}}
+        position={{ lat: bucket.ltAvg, lng: bucket.lnAvg }}
+        id={bucket.val}
+        key={bucket.val}
+      />
+      )
+    }
+  })
+};
+
+export const MarkerBounds = () => {
+  const [ markerElements, setMarkerElements ] = useState<ReactElement<MarkerProps>[]>([]);
+  const duration = defaultAnimationDuration;
+
+  const handleViewportChanged = useCallback((bvp: BoundsViewport) => {
+    setMarkerElements(getMarkerElements(bvp, duration));
+  }, [setMarkerElements]);
+
+  return (
+      <MapVEuMap
+          viewport={{center: [ 0, 0 ], zoom: 5}}
+          height="100vh" width="100vw"
+          onViewportChanged={handleViewportChanged}
+          markers={markerElements}
+          animation={{
+            method: "geohash",
+            duration: defaultAnimationDuration,
+            animationFunction: geohashAnimation
+          }}
+          showGrid={true}
+      />
+  );
+};
+

--- a/src/map/MultipleWords.stories.tsx
+++ b/src/map/MultipleWords.stories.tsx
@@ -3,6 +3,7 @@ import {BoundsViewport, MarkerProps} from "./Types";
 import MapVEuMap from "./MapVEuMap";
 import geohashAnimation from "./animation_functions/geohash";
 import testData from './test-data/geoclust-date-binning-testing-all-levels.json';
+import testDataStraddling from './test-data/geoclust-date-dateline-straddling-all-levels.json';
 import BoundsDriftMarker from "./BoundsDriftMarker";
 import { zoomLevelToGeohashLevel, defaultAnimationDuration } from './config/map.json';
 import './TempIconHack';
@@ -11,13 +12,13 @@ export default {
   title: 'DK multiple worlds/Marker Bounds',
 };
 
-const getMarkerElements = ({ bounds, zoomLevel }: BoundsViewport, duration : number) => {
+const getMarkerElements = ({ bounds, zoomLevel }: BoundsViewport, duration : number, data = testData) => {
   const { southWest: { lat: swLat, lng: swLng }, northEast : {lat: neLat, lng: neLng} } = bounds
   console.log(`I've been triggered with bounds=[${swLat},${swLng} TO ${neLat},${neLng}] and zoom=${zoomLevel}`);
 
   const geohashLevel = zoomLevelToGeohashLevel[zoomLevel];
 
-  const buckets = (testData as { [key: string]: any })[`geohash_${geohashLevel}`].facets.geo.buckets.filter((bucket: any) => {
+  const buckets = (data as { [key: string]: any })[`geohash_${geohashLevel}`].facets.geo.buckets.filter((bucket: any) => {
     const ltAvg : number = bucket.ltAvg;
     const lnAvg : number = bucket.lnAvg;
     return ltAvg > bounds.southWest.lat &&
@@ -51,7 +52,7 @@ export const MarkerBounds = () => {
 
   return (
       <MapVEuMap
-          viewport={{center: [ 0, 0 ], zoom: 5}}
+          viewport={{center: [ 0, 0 ], zoom: 2}}
           height="100vh" width="100vw"
           onViewportChanged={handleViewportChanged}
           markers={markerElements}
@@ -64,4 +65,30 @@ export const MarkerBounds = () => {
       />
   );
 };
+
+
+export const DatelineData = () => {
+  const [ markerElements, setMarkerElements ] = useState<ReactElement<MarkerProps>[]>([]);
+  const duration = defaultAnimationDuration;
+
+  const handleViewportChanged = useCallback((bvp: BoundsViewport) => {
+    setMarkerElements(getMarkerElements(bvp, duration, testDataStraddling));
+  }, [setMarkerElements]);
+
+  return (
+      <MapVEuMap
+          viewport={{center: [ 0, 0 ], zoom: 2}}
+          height="100vh" width="100vw"
+          onViewportChanged={handleViewportChanged}
+          markers={markerElements}
+          animation={{
+            method: "geohash",
+            duration: defaultAnimationDuration,
+            animationFunction: geohashAnimation
+          }}
+          showGrid={true}
+      />
+  );
+};
+
 

--- a/src/map/test-data/geoclust-date-dateline-straddling-all-levels.json
+++ b/src/map/test-data/geoclust-date-dateline-straddling-all-levels.json
@@ -1,0 +1,2032 @@
+{
+  "geohash_7": {
+    "facets": {
+      "geo": {
+        "buckets": [
+          {
+            "term": {
+              "between": {
+                "count": 72
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 60,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 12,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2svsk8x",
+            "count": 72,
+            "ltAvg": -17.531099999999995,
+            "ltMin": -17.5311,
+            "ltMax": -17.5311,
+            "lnAvg": -149.5580000000002,
+            "lnMin": -149.558,
+            "lnMax": -149.558
+          },
+          {
+            "term": {
+              "between": {
+                "count": 9
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 9,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "88256cp",
+            "count": 9,
+            "ltAvg": 1.9840000000000002,
+            "ltMin": 1.984,
+            "ltMax": 1.984,
+            "lnAvg": -157.369,
+            "lnMin": -157.369,
+            "lnMax": -157.369
+          },
+          {
+            "term": {
+              "between": {
+                "count": 8
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 8,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4vsf",
+            "count": 8,
+            "ltAvg": -17.771,
+            "ltMin": -17.771,
+            "ltMax": -17.771,
+            "lnAvg": 177.433,
+            "lnMin": 177.433,
+            "lnMax": 177.433
+          },
+          {
+            "term": {
+              "between": {
+                "count": 2
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 2,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4vmr",
+            "count": 2,
+            "ltAvg": -17.768,
+            "ltMin": -17.768,
+            "ltMax": -17.768,
+            "lnAvg": 177.428,
+            "lnMin": 177.428,
+            "lnMax": 177.428
+          },
+          {
+            "term": {
+              "between": {
+                "count": 2
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 2,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4vse",
+            "count": 2,
+            "ltAvg": -17.773,
+            "ltMin": -17.773,
+            "ltMax": -17.773,
+            "lnAvg": 177.434,
+            "lnMin": 177.434,
+            "lnMax": 177.434
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2svekjr",
+            "count": 1,
+            "ltAvg": -17.68,
+            "ltMin": -17.68,
+            "ltMax": -17.68,
+            "lnAvg": -149.58,
+            "lnMin": -149.58,
+            "lnMax": -149.58
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2th45k3",
+            "count": 1,
+            "ltAvg": -16.5,
+            "ltMin": -16.5,
+            "ltMax": -16.5,
+            "lnAvg": -151.73,
+            "lnMin": -151.73,
+            "lnMax": -151.73
+          },
+          {
+            "term": {
+              "between": {
+                "count": 1
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 1,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4sg3",
+            "count": 1,
+            "ltAvg": -17.823,
+            "ltMin": -17.823,
+            "ltMax": -17.823,
+            "lnAvg": 177.398,
+            "lnMin": 177.398,
+            "lnMax": 177.398
+          },
+          {
+            "term": {
+              "between": {
+                "count": 1
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 1,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4vyh",
+            "count": 1,
+            "ltAvg": -17.764,
+            "ltMin": -17.764,
+            "ltMax": -17.764,
+            "lnAvg": 177.446,
+            "lnMin": 177.446,
+            "lnMax": 177.446
+          },
+          {
+            "term": {
+              "between": {
+                "count": 1
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 1,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4yt2",
+            "count": 1,
+            "ltAvg": -17.769,
+            "ltMin": -17.769,
+            "ltMax": -17.769,
+            "lnAvg": 177.474,
+            "lnMin": 177.474,
+            "lnMax": 177.474
+          }
+        ]
+      },
+      "count": 98
+    },
+    "response": {
+      "docs": [],
+      "start": 0,
+      "numFound": 98
+    },
+    "responseHeader": {
+      "params": {
+        "wt": "json",
+        "rows": "0",
+        "sort": "id asc",
+        "json": "{\n\t\t\"filter\": [\n                  \"bundle:pop_sample\",\n\t\t  \"has_geodata:true\",\n                  \"geolocations_cvterms:(\\\"French Polynesia\\\" OR Fiji OR Kiribati)\"\n                ],\n\t\t\"facet\": {\n\t          \"geo\": {\n\t \t    \"type\": \"terms\",\n\t\t    \"field\": \"${geo:geohash_3}\",\n\t\t    \"limit\": -1,\n\t\t    \"mincount\": 1,\n\t\t    \"sort\": {\n\t\t\t\"count\": \"desc\"\n\t\t    },\n\t\t    \"facet\": {\n\t\t\t\"ltAvg\": \"avg(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMin\": \"min(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMax\": \"max(geo_coords_ll_0_coordinate)\",\n\t\t\t\"lnAvg\": \"avg(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMin\": \"min(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMax\": \"max(geo_coords_ll_1_coordinate)\",\n\t\t\tatomicCount: \"unique(${geomax:geohash_7})\",\n\t\t\t\"term\": {\n\t\t\t\t\"type\": \"range\",\n\t\t\t\t\"field\": \"${term:collection_date}\",\n\t\t\t\t\"start\": \"2000-01-01T00:00:00Z\",\n                                \"end\": \"2020-01-01T00:00:00Z\",\n                                \"gap\": \"+4YEARS\",\n\t\t\t\t\"mincount\": 0,\n                                \"other\": \"all\"\n\t\t\t}\n\t\t    }\n                 }\n               }\n            }",
+        "q": "*:*",
+        "geo": "geohash_7"
+      },
+      "QTime": 401,
+      "status": 0
+    }
+  },
+  "geohash_6": {
+    "facets": {
+      "geo": {
+        "buckets": [
+          {
+            "term": {
+              "between": {
+                "count": 72
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 60,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 12,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2svsk8",
+            "count": 72,
+            "ltAvg": -17.531099999999995,
+            "ltMin": -17.5311,
+            "ltMax": -17.5311,
+            "lnAvg": -149.5580000000002,
+            "lnMin": -149.558,
+            "lnMax": -149.558
+          },
+          {
+            "term": {
+              "between": {
+                "count": 10
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 10,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 2,
+            "val": "ruy4vs",
+            "count": 10,
+            "ltAvg": -17.7714,
+            "ltMin": -17.773,
+            "ltMax": -17.771,
+            "lnAvg": 177.4332,
+            "lnMin": 177.433,
+            "lnMax": 177.434
+          },
+          {
+            "term": {
+              "between": {
+                "count": 9
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 9,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "88256c",
+            "count": 9,
+            "ltAvg": 1.9840000000000002,
+            "ltMin": 1.984,
+            "ltMax": 1.984,
+            "lnAvg": -157.369,
+            "lnMin": -157.369,
+            "lnMax": -157.369
+          },
+          {
+            "term": {
+              "between": {
+                "count": 2
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 2,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4vm",
+            "count": 2,
+            "ltAvg": -17.768,
+            "ltMin": -17.768,
+            "ltMax": -17.768,
+            "lnAvg": 177.428,
+            "lnMin": 177.428,
+            "lnMax": 177.428
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2svekj",
+            "count": 1,
+            "ltAvg": -17.68,
+            "ltMin": -17.68,
+            "ltMax": -17.68,
+            "lnAvg": -149.58,
+            "lnMin": -149.58,
+            "lnMax": -149.58
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2th45k",
+            "count": 1,
+            "ltAvg": -16.5,
+            "ltMin": -16.5,
+            "ltMax": -16.5,
+            "lnAvg": -151.73,
+            "lnMin": -151.73,
+            "lnMax": -151.73
+          },
+          {
+            "term": {
+              "between": {
+                "count": 1
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 1,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4sg",
+            "count": 1,
+            "ltAvg": -17.823,
+            "ltMin": -17.823,
+            "ltMax": -17.823,
+            "lnAvg": 177.398,
+            "lnMin": 177.398,
+            "lnMax": 177.398
+          },
+          {
+            "term": {
+              "between": {
+                "count": 1
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 1,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4vy",
+            "count": 1,
+            "ltAvg": -17.764,
+            "ltMin": -17.764,
+            "ltMax": -17.764,
+            "lnAvg": 177.446,
+            "lnMin": 177.446,
+            "lnMax": 177.446
+          },
+          {
+            "term": {
+              "between": {
+                "count": 1
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 1,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4yt",
+            "count": 1,
+            "ltAvg": -17.769,
+            "ltMin": -17.769,
+            "ltMax": -17.769,
+            "lnAvg": 177.474,
+            "lnMin": 177.474,
+            "lnMax": 177.474
+          }
+        ]
+      },
+      "count": 98
+    },
+    "response": {
+      "docs": [],
+      "start": 0,
+      "numFound": 98
+    },
+    "responseHeader": {
+      "params": {
+        "wt": "json",
+        "rows": "0",
+        "sort": "id asc",
+        "json": "{\n\t\t\"filter\": [\n                  \"bundle:pop_sample\",\n\t\t  \"has_geodata:true\",\n                  \"geolocations_cvterms:(\\\"French Polynesia\\\" OR Fiji OR Kiribati)\"\n                ],\n\t\t\"facet\": {\n\t          \"geo\": {\n\t \t    \"type\": \"terms\",\n\t\t    \"field\": \"${geo:geohash_3}\",\n\t\t    \"limit\": -1,\n\t\t    \"mincount\": 1,\n\t\t    \"sort\": {\n\t\t\t\"count\": \"desc\"\n\t\t    },\n\t\t    \"facet\": {\n\t\t\t\"ltAvg\": \"avg(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMin\": \"min(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMax\": \"max(geo_coords_ll_0_coordinate)\",\n\t\t\t\"lnAvg\": \"avg(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMin\": \"min(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMax\": \"max(geo_coords_ll_1_coordinate)\",\n\t\t\tatomicCount: \"unique(${geomax:geohash_7})\",\n\t\t\t\"term\": {\n\t\t\t\t\"type\": \"range\",\n\t\t\t\t\"field\": \"${term:collection_date}\",\n\t\t\t\t\"start\": \"2000-01-01T00:00:00Z\",\n                                \"end\": \"2020-01-01T00:00:00Z\",\n                                \"gap\": \"+4YEARS\",\n\t\t\t\t\"mincount\": 0,\n                                \"other\": \"all\"\n\t\t\t}\n\t\t    }\n                 }\n               }\n            }",
+        "q": "*:*",
+        "geo": "geohash_6"
+      },
+      "QTime": 82,
+      "status": 0
+    }
+  },
+  "geohash_5": {
+    "facets": {
+      "geo": {
+        "buckets": [
+          {
+            "term": {
+              "between": {
+                "count": 72
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 60,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 12,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2svsk",
+            "count": 72,
+            "ltAvg": -17.531099999999995,
+            "ltMin": -17.5311,
+            "ltMax": -17.5311,
+            "lnAvg": -149.5580000000002,
+            "lnMin": -149.558,
+            "lnMax": -149.558
+          },
+          {
+            "term": {
+              "between": {
+                "count": 13
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 13,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 4,
+            "val": "ruy4v",
+            "count": 13,
+            "ltAvg": -17.77030769230769,
+            "ltMin": -17.773,
+            "ltMax": -17.764,
+            "lnAvg": 177.43338461538463,
+            "lnMin": 177.428,
+            "lnMax": 177.446
+          },
+          {
+            "term": {
+              "between": {
+                "count": 9
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 9,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "88256",
+            "count": 9,
+            "ltAvg": 1.9840000000000002,
+            "ltMin": 1.984,
+            "ltMax": 1.984,
+            "lnAvg": -157.369,
+            "lnMin": -157.369,
+            "lnMax": -157.369
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2svek",
+            "count": 1,
+            "ltAvg": -17.68,
+            "ltMin": -17.68,
+            "ltMax": -17.68,
+            "lnAvg": -149.58,
+            "lnMin": -149.58,
+            "lnMax": -149.58
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2th45",
+            "count": 1,
+            "ltAvg": -16.5,
+            "ltMin": -16.5,
+            "ltMax": -16.5,
+            "lnAvg": -151.73,
+            "lnMin": -151.73,
+            "lnMax": -151.73
+          },
+          {
+            "term": {
+              "between": {
+                "count": 1
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 1,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4s",
+            "count": 1,
+            "ltAvg": -17.823,
+            "ltMin": -17.823,
+            "ltMax": -17.823,
+            "lnAvg": 177.398,
+            "lnMin": 177.398,
+            "lnMax": 177.398
+          },
+          {
+            "term": {
+              "between": {
+                "count": 1
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 1,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "ruy4y",
+            "count": 1,
+            "ltAvg": -17.769,
+            "ltMin": -17.769,
+            "ltMax": -17.769,
+            "lnAvg": 177.474,
+            "lnMin": 177.474,
+            "lnMax": 177.474
+          }
+        ]
+      },
+      "count": 98
+    },
+    "response": {
+      "docs": [],
+      "start": 0,
+      "numFound": 98
+    },
+    "responseHeader": {
+      "params": {
+        "wt": "json",
+        "rows": "0",
+        "sort": "id asc",
+        "json": "{\n\t\t\"filter\": [\n                  \"bundle:pop_sample\",\n\t\t  \"has_geodata:true\",\n                  \"geolocations_cvterms:(\\\"French Polynesia\\\" OR Fiji OR Kiribati)\"\n                ],\n\t\t\"facet\": {\n\t          \"geo\": {\n\t \t    \"type\": \"terms\",\n\t\t    \"field\": \"${geo:geohash_3}\",\n\t\t    \"limit\": -1,\n\t\t    \"mincount\": 1,\n\t\t    \"sort\": {\n\t\t\t\"count\": \"desc\"\n\t\t    },\n\t\t    \"facet\": {\n\t\t\t\"ltAvg\": \"avg(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMin\": \"min(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMax\": \"max(geo_coords_ll_0_coordinate)\",\n\t\t\t\"lnAvg\": \"avg(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMin\": \"min(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMax\": \"max(geo_coords_ll_1_coordinate)\",\n\t\t\tatomicCount: \"unique(${geomax:geohash_7})\",\n\t\t\t\"term\": {\n\t\t\t\t\"type\": \"range\",\n\t\t\t\t\"field\": \"${term:collection_date}\",\n\t\t\t\t\"start\": \"2000-01-01T00:00:00Z\",\n                                \"end\": \"2020-01-01T00:00:00Z\",\n                                \"gap\": \"+4YEARS\",\n\t\t\t\t\"mincount\": 0,\n                                \"other\": \"all\"\n\t\t\t}\n\t\t    }\n                 }\n               }\n            }",
+        "q": "*:*",
+        "geo": "geohash_5"
+      },
+      "QTime": 69,
+      "status": 0
+    }
+  },
+  "geohash_4": {
+    "facets": {
+      "geo": {
+        "buckets": [
+          {
+            "term": {
+              "between": {
+                "count": 72
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 60,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 12,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2svs",
+            "count": 72,
+            "ltAvg": -17.531099999999995,
+            "ltMin": -17.5311,
+            "ltMax": -17.5311,
+            "lnAvg": -149.5580000000002,
+            "lnMin": -149.558,
+            "lnMax": -149.558
+          },
+          {
+            "term": {
+              "between": {
+                "count": 15
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 15,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 6,
+            "val": "ruy4",
+            "count": 15,
+            "ltAvg": -17.77373333333333,
+            "ltMin": -17.823,
+            "ltMax": -17.764,
+            "lnAvg": 177.43373333333332,
+            "lnMin": 177.398,
+            "lnMax": 177.474
+          },
+          {
+            "term": {
+              "between": {
+                "count": 9
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 9,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "8825",
+            "count": 9,
+            "ltAvg": 1.9840000000000002,
+            "ltMin": 1.984,
+            "ltMax": 1.984,
+            "lnAvg": -157.369,
+            "lnMin": -157.369,
+            "lnMax": -157.369
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2sve",
+            "count": 1,
+            "ltAvg": -17.68,
+            "ltMin": -17.68,
+            "ltMax": -17.68,
+            "lnAvg": -149.58,
+            "lnMin": -149.58,
+            "lnMax": -149.58
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2th4",
+            "count": 1,
+            "ltAvg": -16.5,
+            "ltMin": -16.5,
+            "ltMax": -16.5,
+            "lnAvg": -151.73,
+            "lnMin": -151.73,
+            "lnMax": -151.73
+          }
+        ]
+      },
+      "count": 98
+    },
+    "response": {
+      "docs": [],
+      "start": 0,
+      "numFound": 98
+    },
+    "responseHeader": {
+      "params": {
+        "wt": "json",
+        "rows": "0",
+        "sort": "id asc",
+        "json": "{\n\t\t\"filter\": [\n                  \"bundle:pop_sample\",\n\t\t  \"has_geodata:true\",\n                  \"geolocations_cvterms:(\\\"French Polynesia\\\" OR Fiji OR Kiribati)\"\n                ],\n\t\t\"facet\": {\n\t          \"geo\": {\n\t \t    \"type\": \"terms\",\n\t\t    \"field\": \"${geo:geohash_3}\",\n\t\t    \"limit\": -1,\n\t\t    \"mincount\": 1,\n\t\t    \"sort\": {\n\t\t\t\"count\": \"desc\"\n\t\t    },\n\t\t    \"facet\": {\n\t\t\t\"ltAvg\": \"avg(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMin\": \"min(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMax\": \"max(geo_coords_ll_0_coordinate)\",\n\t\t\t\"lnAvg\": \"avg(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMin\": \"min(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMax\": \"max(geo_coords_ll_1_coordinate)\",\n\t\t\tatomicCount: \"unique(${geomax:geohash_7})\",\n\t\t\t\"term\": {\n\t\t\t\t\"type\": \"range\",\n\t\t\t\t\"field\": \"${term:collection_date}\",\n\t\t\t\t\"start\": \"2000-01-01T00:00:00Z\",\n                                \"end\": \"2020-01-01T00:00:00Z\",\n                                \"gap\": \"+4YEARS\",\n\t\t\t\t\"mincount\": 0,\n                                \"other\": \"all\"\n\t\t\t}\n\t\t    }\n                 }\n               }\n            }",
+        "q": "*:*",
+        "geo": "geohash_4"
+      },
+      "QTime": 65,
+      "status": 0
+    }
+  },
+  "geohash_3": {
+    "facets": {
+      "geo": {
+        "buckets": [
+          {
+            "term": {
+              "between": {
+                "count": 72
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 60,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 12,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 2,
+            "val": "2sv",
+            "count": 73,
+            "ltAvg": -17.533139726027393,
+            "ltMin": -17.68,
+            "ltMax": -17.5311,
+            "lnAvg": -149.55830136986322,
+            "lnMin": -149.58,
+            "lnMax": -149.558
+          },
+          {
+            "term": {
+              "between": {
+                "count": 15
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 15,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 6,
+            "val": "ruy",
+            "count": 15,
+            "ltAvg": -17.77373333333333,
+            "ltMin": -17.823,
+            "ltMax": -17.764,
+            "lnAvg": 177.43373333333332,
+            "lnMin": 177.398,
+            "lnMax": 177.474
+          },
+          {
+            "term": {
+              "between": {
+                "count": 9
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 9,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "882",
+            "count": 9,
+            "ltAvg": 1.9840000000000002,
+            "ltMin": 1.984,
+            "ltMax": 1.984,
+            "lnAvg": -157.369,
+            "lnMin": -157.369,
+            "lnMax": -157.369
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2th",
+            "count": 1,
+            "ltAvg": -16.5,
+            "ltMin": -16.5,
+            "ltMax": -16.5,
+            "lnAvg": -151.73,
+            "lnMin": -151.73,
+            "lnMax": -151.73
+          }
+        ]
+      },
+      "count": 98
+    },
+    "response": {
+      "docs": [],
+      "start": 0,
+      "numFound": 98
+    },
+    "responseHeader": {
+      "params": {
+        "wt": "json",
+        "rows": "0",
+        "sort": "id asc",
+        "json": "{\n\t\t\"filter\": [\n                  \"bundle:pop_sample\",\n\t\t  \"has_geodata:true\",\n                  \"geolocations_cvterms:(\\\"French Polynesia\\\" OR Fiji OR Kiribati)\"\n                ],\n\t\t\"facet\": {\n\t          \"geo\": {\n\t \t    \"type\": \"terms\",\n\t\t    \"field\": \"${geo:geohash_3}\",\n\t\t    \"limit\": -1,\n\t\t    \"mincount\": 1,\n\t\t    \"sort\": {\n\t\t\t\"count\": \"desc\"\n\t\t    },\n\t\t    \"facet\": {\n\t\t\t\"ltAvg\": \"avg(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMin\": \"min(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMax\": \"max(geo_coords_ll_0_coordinate)\",\n\t\t\t\"lnAvg\": \"avg(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMin\": \"min(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMax\": \"max(geo_coords_ll_1_coordinate)\",\n\t\t\tatomicCount: \"unique(${geomax:geohash_7})\",\n\t\t\t\"term\": {\n\t\t\t\t\"type\": \"range\",\n\t\t\t\t\"field\": \"${term:collection_date}\",\n\t\t\t\t\"start\": \"2000-01-01T00:00:00Z\",\n                                \"end\": \"2020-01-01T00:00:00Z\",\n                                \"gap\": \"+4YEARS\",\n\t\t\t\t\"mincount\": 0,\n                                \"other\": \"all\"\n\t\t\t}\n\t\t    }\n                 }\n               }\n            }",
+        "q": "*:*",
+        "geo": "geohash_3"
+      },
+      "QTime": 62,
+      "status": 0
+    }
+  },
+  "geohash_2": {
+    "facets": {
+      "geo": {
+        "buckets": [
+          {
+            "term": {
+              "between": {
+                "count": 72
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 60,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 12,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 2,
+            "val": "2s",
+            "count": 73,
+            "ltAvg": -17.533139726027393,
+            "ltMin": -17.68,
+            "ltMax": -17.5311,
+            "lnAvg": -149.55830136986322,
+            "lnMin": -149.58,
+            "lnMax": -149.558
+          },
+          {
+            "term": {
+              "between": {
+                "count": 15
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 15,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 6,
+            "val": "ru",
+            "count": 15,
+            "ltAvg": -17.77373333333333,
+            "ltMin": -17.823,
+            "ltMax": -17.764,
+            "lnAvg": 177.43373333333332,
+            "lnMin": 177.398,
+            "lnMax": 177.474
+          },
+          {
+            "term": {
+              "between": {
+                "count": 9
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 9,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "88",
+            "count": 9,
+            "ltAvg": 1.9840000000000002,
+            "ltMin": 1.984,
+            "ltMax": 1.984,
+            "lnAvg": -157.369,
+            "lnMin": -157.369,
+            "lnMax": -157.369
+          },
+          {
+            "term": {
+              "between": {
+                "count": 0
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 1
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "2t",
+            "count": 1,
+            "ltAvg": -16.5,
+            "ltMin": -16.5,
+            "ltMax": -16.5,
+            "lnAvg": -151.73,
+            "lnMin": -151.73,
+            "lnMax": -151.73
+          }
+        ]
+      },
+      "count": 98
+    },
+    "response": {
+      "docs": [],
+      "start": 0,
+      "numFound": 98
+    },
+    "responseHeader": {
+      "params": {
+        "wt": "json",
+        "rows": "0",
+        "sort": "id asc",
+        "json": "{\n\t\t\"filter\": [\n                  \"bundle:pop_sample\",\n\t\t  \"has_geodata:true\",\n                  \"geolocations_cvterms:(\\\"French Polynesia\\\" OR Fiji OR Kiribati)\"\n                ],\n\t\t\"facet\": {\n\t          \"geo\": {\n\t \t    \"type\": \"terms\",\n\t\t    \"field\": \"${geo:geohash_3}\",\n\t\t    \"limit\": -1,\n\t\t    \"mincount\": 1,\n\t\t    \"sort\": {\n\t\t\t\"count\": \"desc\"\n\t\t    },\n\t\t    \"facet\": {\n\t\t\t\"ltAvg\": \"avg(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMin\": \"min(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMax\": \"max(geo_coords_ll_0_coordinate)\",\n\t\t\t\"lnAvg\": \"avg(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMin\": \"min(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMax\": \"max(geo_coords_ll_1_coordinate)\",\n\t\t\tatomicCount: \"unique(${geomax:geohash_7})\",\n\t\t\t\"term\": {\n\t\t\t\t\"type\": \"range\",\n\t\t\t\t\"field\": \"${term:collection_date}\",\n\t\t\t\t\"start\": \"2000-01-01T00:00:00Z\",\n                                \"end\": \"2020-01-01T00:00:00Z\",\n                                \"gap\": \"+4YEARS\",\n\t\t\t\t\"mincount\": 0,\n                                \"other\": \"all\"\n\t\t\t}\n\t\t    }\n                 }\n               }\n            }",
+        "q": "*:*",
+        "geo": "geohash_2"
+      },
+      "QTime": 4,
+      "status": 0
+    }
+  },
+  "geohash_1": {
+    "facets": {
+      "geo": {
+        "buckets": [
+          {
+            "term": {
+              "between": {
+                "count": 72
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 2
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 60,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 12,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 3,
+            "val": "2",
+            "count": 74,
+            "ltAvg": -17.519178378378374,
+            "ltMin": -17.68,
+            "ltMax": -16.5,
+            "lnAvg": -149.58764864864887,
+            "lnMin": -151.73,
+            "lnMax": -149.558
+          },
+          {
+            "term": {
+              "between": {
+                "count": 15
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 15,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 6,
+            "val": "r",
+            "count": 15,
+            "ltAvg": -17.77373333333333,
+            "ltMin": -17.823,
+            "ltMax": -17.764,
+            "lnAvg": 177.43373333333332,
+            "lnMin": 177.398,
+            "lnMax": 177.474
+          },
+          {
+            "term": {
+              "between": {
+                "count": 9
+              },
+              "after": {
+                "count": 0
+              },
+              "before": {
+                "count": 0
+              },
+              "buckets": [
+                {
+                  "count": 0,
+                  "val": "2000-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2004-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2008-01-01T00:00:00Z"
+                },
+                {
+                  "count": 0,
+                  "val": "2012-01-01T00:00:00Z"
+                },
+                {
+                  "count": 9,
+                  "val": "2016-01-01T00:00:00Z"
+                }
+              ]
+            },
+            "atomicCount": 1,
+            "val": "8",
+            "count": 9,
+            "ltAvg": 1.9840000000000002,
+            "ltMin": 1.984,
+            "ltMax": 1.984,
+            "lnAvg": -157.369,
+            "lnMin": -157.369,
+            "lnMax": -157.369
+          }
+        ]
+      },
+      "count": 98
+    },
+    "response": {
+      "docs": [],
+      "start": 0,
+      "numFound": 98
+    },
+    "responseHeader": {
+      "params": {
+        "wt": "json",
+        "rows": "0",
+        "sort": "id asc",
+        "json": "{\n\t\t\"filter\": [\n                  \"bundle:pop_sample\",\n\t\t  \"has_geodata:true\",\n                  \"geolocations_cvterms:(\\\"French Polynesia\\\" OR Fiji OR Kiribati)\"\n                ],\n\t\t\"facet\": {\n\t          \"geo\": {\n\t \t    \"type\": \"terms\",\n\t\t    \"field\": \"${geo:geohash_3}\",\n\t\t    \"limit\": -1,\n\t\t    \"mincount\": 1,\n\t\t    \"sort\": {\n\t\t\t\"count\": \"desc\"\n\t\t    },\n\t\t    \"facet\": {\n\t\t\t\"ltAvg\": \"avg(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMin\": \"min(geo_coords_ll_0_coordinate)\",\n\t\t\t\"ltMax\": \"max(geo_coords_ll_0_coordinate)\",\n\t\t\t\"lnAvg\": \"avg(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMin\": \"min(geo_coords_ll_1_coordinate)\",\n\t\t\t\"lnMax\": \"max(geo_coords_ll_1_coordinate)\",\n\t\t\tatomicCount: \"unique(${geomax:geohash_7})\",\n\t\t\t\"term\": {\n\t\t\t\t\"type\": \"range\",\n\t\t\t\t\"field\": \"${term:collection_date}\",\n\t\t\t\t\"start\": \"2000-01-01T00:00:00Z\",\n                                \"end\": \"2020-01-01T00:00:00Z\",\n                                \"gap\": \"+4YEARS\",\n\t\t\t\t\"mincount\": 0,\n                                \"other\": \"all\"\n\t\t\t}\n\t\t    }\n                 }\n               }\n            }",
+        "q": "*:*",
+        "geo": "geohash_1"
+      },
+      "QTime": 549,
+      "status": 0
+    }
+  }
+}


### PR DESCRIPTION
@bobular I have tried several ways to address the issue of multiple worlds

- The issue of multiple worlds is common for all map apps (like Google map, etc.)
- there seems to be a way to show markers at multiple worlds, but it is too much hassle, IMO
	- just FYI, the basic idea for that is that since a single world is in the range of -180 - +180 in longitude, multiple markers are made with +/-360 longitudes
		- doesn't make sense to me, so discarded this approach

For this reason, tried several ways Instead to alleviate this issue and finally suggested the following:
	- used MarkerBounds.stories.tsx story but this implementation should work for all stories with map
	- changes are made at MapVEuMap.tsx & CustomGridLayer.tsx: see below description for details

- minZoom needs to be 2 (FHD level resolution) or 3 (4K): set to be 2 for now
- only showing single world by setting maxBounds of (-90 - +90), (-180 - +180)
- at tilelayer, only loading/requesting single world map tiles using bounds and noWrap options
	- thus, depending on one's screen size, some grey area beyond the single map is shown
- one issue was that mouse panning/dragging caused unexpected behaviors
	- tried worldCopyJump option (provided by leaflet) but it was not that satisfactory
		- experienced inconsistent behavior like not correctly showing markers & grid lines
	- thus, it is decided to set bounds for panning: only panning within the single map (using maxBoundsViscosity option) and no more panning at bounds
- Another issue was that grid lines (CustomGridLayer) were shown beyond the single map, i.e., continuously showing grid lines at grey area
	- found a solution by setting bounds to be the single map: modified CustomGridLayer component
